### PR TITLE
feat: 챌린지 상태 버튼 컴포넌트 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,3 +10,11 @@ input:-webkit-autofill:active {
   -webkit-transition: background-color 9999s ease-out;
   -webkit-box-shadow: 0 0 0px 1000px white inset !important;
 }
+
+.translate-x-custom_100 {
+  transform: translateX(calc(100% - 8px));
+}
+
+.translate-x-custom_200 {
+  transform: translateX(calc(200% - 16px));
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,9 +1,21 @@
+'use client'
+
+import ChallengeStatusButton from '@/components/ChallengeStatusButton'
 import ChallengeCard from '@/components/ChellengeCard'
+import { ChallengeStatus } from '@/types/ChallengeStatus'
+import { useState } from 'react'
 
 export default function Home() {
+  const [challengeStatus, setChallengeStatus] =
+    useState<ChallengeStatus>('SCHEDULED')
+
   return (
     <div className="w-full h-full flex flex-col items-center justify-center">
       <h1 className="text-2xl mb-4">메인 페이지</h1>
+      <ChallengeStatusButton
+        challengeStatus={challengeStatus}
+        setChallengeStatus={setChallengeStatus}
+      />
       <div className="w-full flex justify-center">
         <ChallengeCard
           id={1}

--- a/src/components/ChallengeStatusButton.tsx
+++ b/src/components/ChallengeStatusButton.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable no-nested-ternary */
+
+'use client'
+
+import { ChallengeStatus } from '@/types/ChallengeStatus'
+import { Dispatch, SetStateAction } from 'react'
+
+interface Props {
+  challengeStatus: ChallengeStatus
+  setChallengeStatus: Dispatch<SetStateAction<ChallengeStatus>>
+}
+export default function ChallengeStatusButton({
+  challengeStatus,
+  setChallengeStatus,
+}: Props) {
+  return (
+    <div className="relative w-full grid grid-cols-3 bg-_grey-200 bg-opacity-40 px-2 py-[.375rem] rounded-3xl mb-9 text-lg">
+      <div
+        className={`z-0 absolute px-[.375rem] py-2 w-1/3 left-2 right-2 top-[.375rem] h-[2.75rem] bg-white rounded-[1.3125rem] transition-transform duration-300 ${challengeStatus === 'SCHEDULED' ? 'translate-x-0' : challengeStatus === 'IN_PROGRESS' ? 'translate-x-custom_100' : 'translate-x-custom_200'}`}
+      />
+      <button
+        type="button"
+        className={`${challengeStatus === 'SCHEDULED' ? 'font-medium' : 'font-normal text-_grey-300'} relative bg-transparent rounded-[1.3125rem] px-5 py-2 transition-colors duration-300`}
+        onClick={() => setChallengeStatus('SCHEDULED')}
+      >
+        진행예정
+      </button>
+      <button
+        type="button"
+        className={`${challengeStatus === 'IN_PROGRESS' ? 'font-medium' : 'font-normal text-_grey-300'} relative bg-transparent rounded-[1.3125rem] px-5 py-2 transition-colors duration-300`}
+        onClick={() => setChallengeStatus('IN_PROGRESS')}
+      >
+        진행중
+      </button>
+      <button
+        type="button"
+        className={`${challengeStatus === 'COMPLETED' ? 'font-medium' : 'font-normal text-_grey-300'} relative bg-transparent rounded-[1.3125rem] px-5 py-2 transition-colors duration-300`}
+        onClick={() => setChallengeStatus('COMPLETED')}
+      >
+        마감
+      </button>
+    </div>
+  )
+}

--- a/src/types/ChallengeStatus.ts
+++ b/src/types/ChallengeStatus.ts
@@ -1,0 +1,1 @@
+export type ChallengeStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETED'


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 

## 📝작업 내용

> 조회하는 챌린지의 상태를 변경하는 버튼 컴포넌트를 추가했습니다. 
zustand를 이용하여 drilling을 줄일까도 했는데, 팀장님이 불필요한 추가는 하지말라고 했었기도 했고, 검색 기능이 없으면 굳이 url params로 상태를 관리하지 않아도 될거같다고 판단해서 useState와 drilling으로 접근했습니다.
조금 부끄러운 global.css 파일을 작성했지만, 개발 일정상 일단 구현을 우선시해서 무시하고 푸시했습니다 ..! ㅎㅎ

### 스크린샷 (선택)

https://github.com/user-attachments/assets/91fe78ea-0472-4bf4-a4f9-c2ad9ceddced



