### PR TITLE
Design/#25 소제목 라벨 컴포넌트추가

### DIFF
--- a/src/components/ui/SectionTitle.tsx
+++ b/src/components/ui/SectionTitle.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  icon: React.ReactNode
+  label: string
+}
+
+export default function SectionTitle({ icon, label }: Props) {
+  return (
+    <h2 className="flex gap-1">
+      <div className="w-4 h-4">{icon}</div>
+      <p className="text-lg font-medium">{label}</p>
+    </h2>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 소제목 라벨 컴포넌트 추가


## 💬리뷰 요구사항(선택)

<img width="236" alt="image" src="https://github.com/user-attachments/assets/1a709fd9-1483-4187-9903-0321710c10cc">

이거 쓸때 사용하심 됩니다 

SectionTitle
