### PR TITLE
Fix/#36 세팅페이지 패딩에러수정

### DIFF
--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -13,9 +13,8 @@ import {
 
 export default function SettingPage() {
   return (
-    <div className="w-full h-full">
-      <div className="absolute inset-0 bg-_grey-100" />
-      <div className="relative w-full h-full flex flex-col items-start justify-center">
+    <div className="-mx-5">
+      <div className="relative w-full flex flex-col items-start justify-center bg-_grey-100">
         <div className="mb-3 w-full">
           <SettingItem
             icon={<EditProfile />}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36 

## 📝작업 내용
> 좌우 패딩 에러를 수정했습니다. 버전 하단 부분이 원래 디자인에서 회색이었으나 min-page적용때문에 페이지 컨피그 수정이 불가피하고, 굳이 회색일필요도 없을 것같아 간단히 패딩 부분만 조절했습니다.

![image](https://github.com/user-attachments/assets/0b89006b-e064-4273-b5d4-7abab8d14f1d)

