### PR TITLE
Feat/#64 메인페이지 챌린지 리스트 api 연결

### DIFF
--- a/src/app/challenge/list/page.tsx
+++ b/src/app/challenge/list/page.tsx
@@ -4,10 +4,29 @@ import ChallengeStatusButton from '@/components/ChallengeStatusButton'
 import ChallengeCard from '@/components/ChallengeCard'
 import { ChallengeStatus } from '@/types/ChallengeStatus'
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getAllChallenge } from '@/services/challenges'
+import { Challenge } from '@/types/Challenge'
 
 export default function ChallengeListPage() {
+  const [filteredChallengeList, setFilteredChallengeList] = useState<
+    Challenge[]
+  >([])
   const [challengeStatus, setChallengeStatus] =
     useState<ChallengeStatus>('SCHEDULED')
+
+  const { data: challengeList } = useQuery({
+    queryKey: ['challengeList'],
+    queryFn: getAllChallenge,
+  })
+
+  if (challengeList && challengeList.length > 0) {
+    setFilteredChallengeList(
+      challengeList.filter(
+        (challenge: Challenge) => challenge.status === challengeStatus,
+      ),
+    )
+  }
 
   return (
     <div className="w-full px-5 pt-4 pb-8">
@@ -17,32 +36,44 @@ export default function ChallengeListPage() {
         tabType="main"
       />
       <div className="w-full flex flex-col justify-center gap-7 mt-9">
+        {filteredChallengeList?.map((challenge: Challenge) => (
+          <ChallengeCard
+            key={challenge?.challengeId}
+            challengeId={challenge?.challengeId}
+            title={challenge?.title}
+            startDate={challenge?.startDate}
+            endDate={challenge?.endDate}
+            participants={challenge?.participants}
+            totalDeposit={challenge?.totalDeposit}
+            image={challenge?.image}
+          />
+        ))}
         <ChallengeCard
-          id="1"
+          challengeId="1"
           title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-08-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
+          startDate="20240701"
+          endDate="20240831"
+          participants="3786"
+          totalDeposit="3201000"
+          image="/image/coffee.jpg"
         />
         <ChallengeCard
-          id="2"
+          challengeId="1"
           title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-08-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
+          startDate="20240701"
+          endDate="20240831"
+          participants="3786"
+          totalDeposit="3201000"
+          image="/image/coffee.jpg"
         />
         <ChallengeCard
-          id="3"
+          challengeId="1"
           title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-07-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
+          startDate="20240701"
+          endDate="20240831"
+          participants="3786"
+          totalDeposit="3201000"
+          image="/image/coffee.jpg"
         />
       </div>
     </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,25 +1,30 @@
 'use client'
 
-import AccountCard from '@/components/AccountCard'
-import FundCard from '@/components/FundCard'
-
 import { Arrow } from '@/public/svg/index'
 import { useState } from 'react'
-import Button from '@/components/ui/Button'
 import { useRouter } from 'next/navigation'
 import Banner from '@/components/banner'
 import SavingsRecommendCard from '@/containers/home/SavingsRecommendCard'
-import MyChallengeCard from '@/components/MyChallengeCard'
-import MiniChallengeCard from '@/components/MiniChallengeCard'
-import ScoreCard from '@/components/ScoreCard'
 import ChallengeCard from '@/components/ChallengeCard'
+import { useQuery } from '@tanstack/react-query'
+import { getAllChallenge } from '@/services/challenges'
+import { Challenge } from '@/types/Challenge.js'
 
 export default function Home() {
   const router = useRouter()
   const [isBannerOpen, setIsBannerOpen] = useState(true)
 
+  const { data: challengeList } = useQuery({
+    queryKey: ['challengeList'],
+    queryFn: getAllChallenge,
+  })
+
+  if (challengeList && challengeList.length > 2) {
+    challengeList.splice(2, challengeList.length - 2)
+  }
+
   return (
-    <div className="w-full h-full flex flex-col">
+    <div className="w-full h-full flex flex-col pb-7">
       <div className="w-full min-h-[3.75rem] flex items-center">
         <h1 className="text-2xl font-bold text-primary/80">돈기부여</h1>
       </div>
@@ -34,110 +39,35 @@ export default function Home() {
         />
       </div>
       <div className="w-full flex flex-col justify-center gap-7 mt-5">
-        <ChallengeCard
-          id="1"
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-08-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
-        />
-        <ChallengeCard
-          id="2"
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-08-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
-        />
-        <ChallengeCard
-          id="3"
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-07-31"
-          participants={3786}
-          fund={3201000}
-          imageUrl="/image/coffee.jpg"
-        />
-        <MyChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-07-31"
-          imageUrl="/image/coffee.jpg"
-          isChallengeSuccessful
-          isSettled={false}
-        />
-        <MyChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-07-31"
-          imageUrl="/image/coffee.jpg"
-          isChallengeSuccessful
-          isSettled
-        />
-        <MyChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-08-01"
-          endDate="2024-08-31"
-          imageUrl="/image/coffee.jpg"
-        />
-        <MyChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-09-01"
-          endDate="2024-09-31"
-          imageUrl="/image/coffee.jpg"
-        />
-        <MiniChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-07-01"
-          endDate="2024-07-31"
-          imageUrl="/image/coffee.jpg"
-          isChallengeSuccessful
-          isSettled={false}
-        />
-        <MiniChallengeCard
-          title="한 달 커피 소비 줄이기"
-          startDate="2024-08-01"
-          endDate="2024-08-31"
-          imageUrl="/image/coffee.jpg"
-          isChatPage
-          participantCount={3291}
-        />
-        <ScoreCard
-          score={130}
-          description="일일 점수"
-          date="8월 27일"
-          additionalScore={10}
-        />
-      </div>
-      <div className="w-full flex flex-col justify-center gap-5 mt-5">
-        <div className="w-full flex justify-center">
-          <FundCard
-            title="한 달 커피 소비 줄이기 기금"
-            participants={3786}
-            fund={3201000}
+        {challengeList?.map((challenge: Challenge) => (
+          <ChallengeCard
+            key={challenge?.challengeId}
+            challengeId={challenge?.challengeId}
+            title={challenge?.title}
+            startDate={challenge?.startDate}
+            endDate={challenge?.endDate}
+            participants={challenge?.participants}
+            totalDeposit={challenge?.totalDeposit}
+            image={challenge?.image}
           />
-        </div>
-        <div className="w-full flex justify-center">
-          <AccountCard
-            account="110-000-000000"
-            balance={210000}
-            accountType="deposit"
-          />
-        </div>
-        <div className="w-full flex justify-center">
-          <AccountCard
-            account="110-000-000000"
-            balance={70000}
-            accountType="saving"
-          />
-        </div>
-        <Button
-          text="모달 사용법"
-          onClick={() => router.push('/modals/example')}
-          className="text-white"
+        ))}
+        <ChallengeCard
+          challengeId="1"
+          title="한 달 커피 소비 줄이기"
+          startDate="20240701"
+          endDate="20240831"
+          participants="3786"
+          totalDeposit="3201000"
+          image="/image/coffee.jpg"
+        />
+        <ChallengeCard
+          challengeId="1"
+          title="한 달 커피 소비 줄이기"
+          startDate="20240701"
+          endDate="20240831"
+          participants="3786"
+          totalDeposit="3201000"
+          image="/image/coffee.jpg"
         />
       </div>
     </div>

--- a/src/components/ChallengeCard.tsx
+++ b/src/components/ChallengeCard.tsx
@@ -5,35 +5,30 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { calculateDday } from '@/utils/calculateDday'
 import Button from '@/components/ui/Button'
-
-interface Props {
-  id: string
-  title: string
-  startDate: string
-  endDate: string
-  participants: number
-  fund: number
-  imageUrl: string
-}
+import { formatDate } from '@/utils/formatDate'
+import { Challenge } from '@/types/Challenge'
 
 export default function ChallengeCard({
-  id,
+  challengeId,
   title,
   startDate,
   endDate,
   participants,
-  fund,
-  imageUrl,
-}: Props) {
+  totalDeposit,
+  image,
+}: Challenge) {
   const router = useRouter()
 
-  const dateRange = `${startDate} ~ ${endDate}`
+  const formattedStartDate = formatDate(startDate)
+  const formattedEndDate = formatDate(endDate)
 
-  const isChallengeEnded = new Date(endDate) < new Date()
+  const dateRange = `${formattedStartDate} ~ ${formattedEndDate}`
+
+  const isChallengeEnded = new Date(formattedEndDate) < new Date()
 
   const handleClick = () => {
     if (!isChallengeEnded) {
-      router.push(`/challenge/${id}`)
+      router.push(`/challenge/${challengeId}`)
     }
   }
 
@@ -59,20 +54,20 @@ export default function ChallengeCard({
           <Button
             text="결과보기"
             className="text-white pointer-events-auto"
-            url={`/challenge/result/${id}`}
+            url={`/challenge/result/${challengeId}`}
           />
         </div>
       )}
       <div className="relative w-full">
         <Image
-          src={imageUrl}
+          src={image}
           alt="Challenge Image"
           height={400}
           width={400}
           className="w-full rounded-t-2xl object-cover aspect-half"
         />
         <div className="absolute top-3 right-4 bg-black text-white text-xs px-5 py-1 rounded-xl">
-          {participants.toLocaleString()}명 참여 중
+          {participants?.toLocaleString()}명 참여 중
         </div>
       </div>
       <div className="p-3 flex flex-col gap-2">
@@ -91,7 +86,7 @@ export default function ChallengeCard({
               누적 기금{' '}
             </span>
             <span className="text-_blue-300 ml-1 font-medium leading-none">
-              {fund.toLocaleString()} 원
+              {totalDeposit?.toLocaleString()} 원
             </span>
           </div>
         </div>

--- a/src/containers/RootLayoutClient.tsx
+++ b/src/containers/RootLayoutClient.tsx
@@ -15,11 +15,11 @@ export default function RootLayoutClient({
     '/recommendation',
   ]
 
-  const hideMenubarDinamicPaths = ['/transfer']
+  const hideMenubarDynamicPaths = ['/transfer']
 
   const shouldHideMenubar =
     hideMenubarPaths.includes(pathname) ||
-    hideMenubarDinamicPaths.map((path) => pathname.startsWith(path))
+    hideMenubarDynamicPaths.some((path) => pathname.startsWith(path))
 
   return (
     <>

--- a/src/services/challenges.ts
+++ b/src/services/challenges.ts
@@ -1,0 +1,6 @@
+import { instance } from '@/services/config/axios'
+
+export const getAllChallenge = async () => {
+  const response = await instance.get('/challenges')
+  return response.data
+}

--- a/src/types/Challenge.ts
+++ b/src/types/Challenge.ts
@@ -1,0 +1,13 @@
+export type Challenge = {
+  challengeId: string
+  type?: string
+  status?: string
+  accountNo?: string
+  startDate: string
+  endDate: string
+  title: string
+  description?: string
+  totalDeposit: string
+  participants: string
+  image: string
+}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,10 @@
+/**
+ * 주어진 날짜 문자열을 `YYYY-MM-DD` 형식으로 변환합니다.
+ *
+ * @param {string} dateString - 변환할 날짜 문자열 (`YYYYMMDD` 형식).
+ * @returns {string} 변환된 날짜 문자열 (`YYYY-MM-DD` 형식).
+ */
+
+export function formatDate(dateString: string) {
+  return dateString.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #64 

## 📝작업 내용

> 메인페이지와 챌린지 리스트에 챌린지 리스트 조회 API를 연결했습니다. 
현재 서버에 챌린지가 추가되어 있지 않아서, 프론트 단에서 더미를 이용해서 UI를 확인하였고, API 결과 반환까지는 제대로 표시되어 믿음으로 merge하고 향후 클라이언트 더미만 제거할 예정입니다. 

