### PR TITLE
Feat/#75 내챌린지 페이지 api 연결 작업

### DIFF
--- a/src/app/challenge/my/[challengeId]/page.tsx
+++ b/src/app/challenge/my/[challengeId]/page.tsx
@@ -1,0 +1,7 @@
+export default function MyChallengeDetail() {
+  return (
+    <div>
+      <h1>챌린지 상세보기 페이지입니다.</h1>
+    </div>
+  )
+}

--- a/src/app/challenge/my/page.tsx
+++ b/src/app/challenge/my/page.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-nested-ternary */
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+'use client'
+
+import ChallengeStatusButton from '@/components/ChallengeStatusButton'
+import MyChallengeCard from '@/components/MyChallengeCard'
+import { getUserInfo } from '@/services/auth'
+import { getMyChallengeList } from '@/services/challenges'
+import { ChallengeStatus } from '@/types/ChallengeStatus'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import { MemberChallengeDetail, MyChallengeList } from '@/types/MyChallenge'
+
+export default function MyChallengePage() {
+  const [challengeStatus, setChallengeStatus] =
+    useState<ChallengeStatus>('SCHEDULED')
+  const [filteredChallengeList, setFilteredChallengeList] =
+    useState<MemberChallengeDetail[]>()
+
+  const { data: user } = useQuery({
+    queryKey: ['user'],
+    queryFn: () => getUserInfo(),
+  })
+
+  const { data: myChallengeList, isPending } = useQuery<MyChallengeList>({
+    queryKey: ['myChallengeList'],
+    queryFn: () => getMyChallengeList(user?.memberId as string),
+    enabled: !!user?.memberId,
+  })
+
+  useEffect(() => {
+    if (!myChallengeList) return
+
+    const filteredList: MemberChallengeDetail[] =
+      myChallengeList?.memberChallengeDetails?.filter(
+        (challenge) => challenge?.status === challengeStatus,
+      )
+    setFilteredChallengeList(filteredList)
+  }, [challengeStatus, myChallengeList])
+
+  return (
+    <div className="pt-6 px-5">
+      <ChallengeStatusButton
+        challengeStatus={challengeStatus}
+        setChallengeStatus={setChallengeStatus}
+        tabType="my"
+      />
+      <div className="mt-7 flex flex-col gap-4">
+        {filteredChallengeList?.map((challenge) => (
+          <MyChallengeCard
+            title={challenge?.title}
+            startDate={challenge?.startDate}
+            endDate={challenge?.endDate}
+            imageUrl={challenge?.image}
+            status={challenge?.status}
+            memberStatus={challenge?.memberStatus}
+            challengeId={challenge?.challengeId}
+            type={challenge?.type}
+          />
+        ))}
+        {!isPending && filteredChallengeList?.length === 0 && (
+          <div className="flex flex-col gap-7 justify-center items-center h-96">
+            <Image
+              src="/gif/crying-face.gif"
+              alt="not-found"
+              width={80}
+              height={80}
+            />
+            <p className="text-center font-medium text-_grey-400">
+              {challengeStatus === 'SCHEDULED'
+                ? '참여예정인'
+                : challengeStatus === 'IN_PROGRESS'
+                  ? '참여중인'
+                  : '완료한'}{' '}
+              챌린지가 없습니다!
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ChallengeButton.tsx
+++ b/src/components/ChallengeButton.tsx
@@ -1,9 +1,18 @@
+'use client'
+
+import { convertTransferType } from '@/utils/convertTransferType'
+import { useRouter } from 'next/navigation'
+
 interface Props {
   status: '참여예정' | '참여중' | '정산필요' | '완료'
   detailPage: boolean
+  type?: string
+  challengeId?: string
 }
 
-function ChallengeButton({ status, detailPage }: Props) {
+function ChallengeButton({ status, detailPage, type, challengeId }: Props) {
+  const router = useRouter()
+
   function renderButtons() {
     const blueButton =
       'w-full py-3 my-4 bg-_blue-300 bg-opacity-15 text-_blue-300 rounded-lg text-center text-sm font-medium'
@@ -19,21 +28,37 @@ function ChallengeButton({ status, detailPage }: Props) {
               <button type="button" className={redButton}>
                 포기하기
               </button>
-              <button type="button" className={blueButton}>
+              <button
+                type="button"
+                className={blueButton}
+                onClick={() =>
+                  router.push(`/chat/${convertTransferType(type as string)}`)
+                }
+              >
                 채팅
               </button>
             </div>
           )
         case '참여중':
           return (
-            <button type="button" className={blueButton}>
+            <button
+              type="button"
+              className={blueButton}
+              onClick={() =>
+                router.push(`/chat/${convertTransferType(type as string)}`)
+              }
+            >
               채팅
             </button>
           )
         case '정산필요':
           return (
             <div className="flex gap-3">
-              <button type="button" className={blueButton}>
+              <button
+                type="button"
+                className={blueButton}
+                onClick={() => router.push(`/challenge/result/${challengeId}`)}
+              >
                 챌린지 전체 결과보기
               </button>
               <button type="button" className={redButton}>
@@ -43,7 +68,11 @@ function ChallengeButton({ status, detailPage }: Props) {
           )
         case '완료':
           return (
-            <button type="button" className={blueButton}>
+            <button
+              type="button"
+              className={blueButton}
+              onClick={() => router.push(`/challenge/result/${challengeId}`)}
+            >
               챌린지 전체 결과보기
             </button>
           )
@@ -56,10 +85,20 @@ function ChallengeButton({ status, detailPage }: Props) {
         case '참여중':
           return (
             <div className="flex gap-3">
-              <button type="button" className={blueButton}>
+              <button
+                type="button"
+                className={blueButton}
+                onClick={() => router.push(`/challenge/my/${challengeId}`)}
+              >
                 챌린지 상세보기
               </button>
-              <button type="button" className={blueButton}>
+              <button
+                type="button"
+                className={blueButton}
+                onClick={() =>
+                  router.push(`/chat/${convertTransferType(type as string)}`)
+                }
+              >
                 채팅
               </button>
             </div>
@@ -67,7 +106,11 @@ function ChallengeButton({ status, detailPage }: Props) {
         case '정산필요':
         case '완료':
           return (
-            <button type="button" className={blueButton}>
+            <button
+              type="button"
+              className={blueButton}
+              onClick={() => router.push(`/challenge/result/${challengeId}`)}
+            >
               챌린지 전체 결과보기
             </button>
           )

--- a/src/components/ChallengeStatusButton.tsx
+++ b/src/components/ChallengeStatusButton.tsx
@@ -2,7 +2,11 @@
 
 'use client'
 
+import { getUserInfo } from '@/services/auth'
+import { getMyChallengeList } from '@/services/challenges'
 import { ChallengeStatus } from '@/types/ChallengeStatus'
+import { MyChallengeList } from '@/types/MyChallenge'
+import { useQuery } from '@tanstack/react-query'
 import { Dispatch, SetStateAction } from 'react'
 
 interface Props {
@@ -15,6 +19,18 @@ export default function ChallengeStatusButton({
   setChallengeStatus,
   tabType,
 }: Props) {
+  const { data: user } = useQuery({
+    queryKey: ['user'],
+    queryFn: () => getUserInfo(),
+    enabled: !!localStorage.getItem('email'),
+  })
+
+  const { data: myChallengeList } = useQuery<MyChallengeList>({
+    queryKey: ['myChallengeList'],
+    queryFn: () => getMyChallengeList(user?.memberId as string),
+    enabled: !!user?.memberId,
+  })
+
   return (
     <div
       className={`relative z-10 w-full grid ${tabType === 'main' ? 'grid-cols-2' : 'grid-cols-3'} bg-[#EDEDED] px-2 py-[.375rem] rounded-3xl mb-9 text-lg`}
@@ -43,7 +59,12 @@ export default function ChallengeStatusButton({
         className={`${challengeStatus === 'COMPLETED' ? 'font-medium' : 'font-normal text-_grey-300'} relative bg-transparent rounded-[1.3125rem] px-5 py-2 transition-colors duration-300 min-w-max`}
         onClick={() => setChallengeStatus('COMPLETED')}
       >
-        마감
+        {tabType === 'main' ? '마감' : '완료'}
+        {!!myChallengeList?.totalCalculatedNum && (
+          <div className="bg-_red rounded-full w-6 h-6 absolute -top-2 right-1/4 z-10 flex justify-center items-center font-medium text-white">
+            {myChallengeList?.totalCalculatedNum}
+          </div>
+        )}
       </button>
     </div>
   )

--- a/src/components/Menubar.tsx
+++ b/src/components/Menubar.tsx
@@ -9,7 +9,7 @@ const getIconColor = (path: string, currentPath: string) =>
 
 const MenuDetails = [
   { path: 'home', component: Home, label: '홈' },
-  { path: `challenge/1`, component: Challenge, label: '챌린지' },
+  { path: `challenge/my`, component: Challenge, label: '챌린지' },
   { path: 'chat', component: Chat, label: '채팅' },
   { path: 'mypage', component: Profile, label: '마이페이지' },
 ]

--- a/src/components/MyChallengeCard.tsx
+++ b/src/components/MyChallengeCard.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image'
 import { calculateDday } from '@/utils/calculateDday'
 import { ArrowRight } from '@/public/svg'
+import { formatDate } from '@/utils/formatDate'
+import { useRouter } from 'next/navigation'
 import ChallengeButton from './ChallengeButton'
 
 interface Props {
@@ -10,8 +12,10 @@ interface Props {
   startDate: string
   endDate: string
   imageUrl: string
-  isChallengeSuccessful?: boolean
-  isSettled?: boolean
+  status?: string
+  memberStatus?: string
+  challengeId?: string
+  type?: string
 }
 
 export default function MyChallengeCard({
@@ -19,12 +23,15 @@ export default function MyChallengeCard({
   startDate,
   endDate,
   imageUrl,
-  isChallengeSuccessful,
-  isSettled,
+  status,
+  memberStatus,
+  challengeId,
+  type,
 }: Props) {
+  const router = useRouter()
   const today = new Date()
-  const start = new Date(startDate)
-  const end = new Date(endDate)
+  const start = new Date(formatDate(startDate))
+  const end = new Date(formatDate(endDate))
 
   const challengeStatus: '참여 예정' | '진행중' | '완료' | '정산필요' = (() => {
     if (today < start) {
@@ -33,8 +40,8 @@ export default function MyChallengeCard({
     if (today >= start && today <= end) {
       return '진행중'
     }
-    if (isChallengeSuccessful) {
-      return isSettled ? '완료' : '정산필요'
+    if (status === 'COMPLETED') {
+      return memberStatus === 'REWARDED' ? '완료' : '정산필요'
     }
     return '완료'
   })()
@@ -58,34 +65,45 @@ export default function MyChallengeCard({
   return (
     <div className="w-full bg-white rounded-2xl px-4 items-center border border_grey-200/50 divide-y divide-_grey-200/50">
       <div className="flex items-center w-full py-4">
-        <div className="flex w-[3.75rem] h-[3.75rem] overflow-hidden rounded-lg mr-3">
+        <div className="flex min-w-[3.75rem] h-[3.75rem] overflow-hidden rounded-lg mr-3">
           <Image
-            src={imageUrl}
+            src={`/image/challenge/${imageUrl}.jpg`}
             alt="Challenge Image"
             height={60}
             width={60}
             className="object-cover"
           />
         </div>
-        <div className="flex flex-col">
-          <span className={`text-xs font-medium ${statusColor}`}>
-            {challengeStatus === '참여 예정' || challengeStatus === '진행중'
-              ? calculateDday(startDate)
-              : challengeStatus}
-          </span>
-          <div className="flex flex-col justify-start">
-            <span className="text-lg font-medium text-black">{title}</span>
-            <span className="text-sm text-_grey-300">
-              {startDate} ~ {endDate}
+        <div
+          role="presentation"
+          className="w-full flex justify-between items-center cursor-pointer"
+          onClick={() => router.push(`/challenge/${challengeId}`)}
+        >
+          <div className="flex flex-col">
+            <span className={`text-xs font-medium ${statusColor}`}>
+              {challengeStatus === '참여 예정' || challengeStatus === '진행중'
+                ? calculateDday(formatDate(startDate))
+                : challengeStatus}
             </span>
+            <div className="flex flex-col justify-start">
+              <span className="text-lg font-medium text-black">{title}</span>
+              <span className="text-sm text-_grey-300">
+                {formatDate(startDate)} ~ {formatDate(endDate)}
+              </span>
+            </div>
           </div>
+          <button type="button" className="ml-auto" aria-label="View details">
+            <ArrowRight />
+          </button>
         </div>
-        <button type="button" className="ml-auto" aria-label="View details">
-          <ArrowRight />
-        </button>
       </div>
       <div className="w-full">
-        <ChallengeButton status={mappedStatus} detailPage={false} />
+        <ChallengeButton
+          status={mappedStatus}
+          detailPage={false}
+          type={type}
+          challengeId={challengeId}
+        />
       </div>
     </div>
   )

--- a/src/constants/url-map.ts
+++ b/src/constants/url-map.ts
@@ -15,12 +15,12 @@ export const URL_LABEL_MAP: UrlMap[] = [
     goBack: false,
   },
   {
-    path: '/challenge/my',
-    label: '내 챌린지',
+    path: '/challenge/list',
+    label: ' ',
     goBack: true,
   },
   {
-    path: '/challenge/list',
+    path: '/challenge/my',
     label: ' ',
     goBack: true,
   },

--- a/src/containers/challenge/[id]/ChallengeInfo.tsx
+++ b/src/containers/challenge/[id]/ChallengeInfo.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   ArrowDown,
@@ -28,6 +28,8 @@ export default function ChallengeInfo() {
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false)
   const [isFailModalOpen, setIsFailModalOpen] = useState(false)
   const challengeId = pathname.split('/')[2]
+  const [scoreMessages, setScoreMessages] = useState<string[]>()
+  const [successCondition, setSuccessCondition] = useState<string>()
 
   const { data: user } = useQuery<UserInfo>({
     queryKey: ['user'],
@@ -57,15 +59,70 @@ export default function ChallengeInfo() {
     enabled: !!accountList?.length,
   })
 
+  const getScoreMessages = (challengeType: string): string[] => {
+    switch (challengeType) {
+      case 'CONSUMPTION_COFFEE':
+        return [
+          '모닝커피 참기, (오전 7시 ~ 오전 10시), + 2',
+          '식후커피 참기, (오전 11시 ~ 오후 2시), + 3',
+          '커피 마실 경우, , - 5',
+        ]
+      case 'CONSUMPTION_DRINK':
+        return [
+          '금요일 안마시기, , + 5',
+          '토요일 안마시기, , + 5',
+          '술을 마실 경우, , - 5',
+        ]
+      case 'CONSUMPTION_DELIVERY':
+        return [
+          '야식 시간대에 안먹기, (오후 9시 ~ 오전 2시), + 5',
+          '배달을 먹을 경우, , - 5',
+        ]
+      default:
+        return []
+    }
+  }
+
+  const getCategoryMessage = (challengeType: string): string => {
+    switch (challengeType) {
+      case 'SAVINGS_SEVEN':
+        return '49일 동안 매일 납입하면'
+      case 'QUIZ_SOLBEING':
+        return ''
+      default:
+        return '카테고리 소비가 지난 달 대비 줄어들면'
+    }
+  }
+
+  useEffect(() => {
+    if (challenge) {
+      const scoreMessageList = getScoreMessages(challenge.type as string)
+      const successConditionMessage = getCategoryMessage(
+        challenge.type as string,
+      )
+      setScoreMessages(scoreMessageList)
+      setSuccessCondition(successConditionMessage)
+    }
+  }, [challenge])
+
   return (
     <div className="flex flex-col gap-[3.75rem] pb-24">
       <div className="mt-7">
-        <div className="text-sm font-normal">절약 챌린지</div>
-        <div className="text-2xl font-medium mt-2">{challenge?.title}</div>
-        <div className="text-base font-normal mt-6">
-          [{challengeTypeToLabel[challenge?.type as ChallengeType]}] 카테고리
-          소비가 지난 달 대비 줄어들면 성공!
+        <div className="text-sm font-normal">
+          {challenge?.type === 'QUIZ_SOLBEING'
+            ? '퀴즈'
+            : challenge?.type === 'SAVINGS_SEVEN'
+              ? '적금'
+              : '절약'}{' '}
+          챌린지
         </div>
+        <div className="text-2xl font-medium mt-2">{challenge?.title}</div>
+        {successCondition && (
+          <div className="text-base font-normal mt-6">
+            [{challengeTypeToLabel[challenge?.type as ChallengeType]}]{' '}
+            {successCondition} 성공!
+          </div>
+        )}
       </div>
       <div>
         <div className="flex space-x-1 items-center">
@@ -78,36 +135,39 @@ export default function ChallengeInfo() {
           </span>
         </div>
       </div>
-      <div>
-        <div className="flex space-x-1 items-center">
-          <Flag />
-          <span className="text-lg font-medium">내 챌린지 성공조건</span>
+      {!!scoreMessages?.length && (
+        <div>
+          <div className="flex space-x-1 items-center">
+            <Flag />
+            <span className="text-lg font-medium">내 챌린지 성공조건</span>
+          </div>
+          <div className="bg-_grey-100 w-full p-4 mt-4 text-center rounded-xl text-sm font-normal">
+            <p>
+              이번 달 나의 [
+              {challengeTypeToLabel[challenge?.type as ChallengeType]}] 소비
+              내역
+            </p>
+            <p className="mt-1">
+              <span className="text-xl font-bold text-primary">
+                {spentMoney?.totalConsumption}
+              </span>{' '}
+              원
+            </p>
+            <p className="mt-5">
+              다음 달 &lt;카페&gt; 소비가{' '}
+              <span className="text-medium text-primary">
+                {spentMoney?.totalConsumption}
+              </span>
+              원 미만이면 성공이에요!
+            </p>
+            <p className="mt-2 text-xs leading-5 text-_grey-400">
+              소비내역 기준은 챌린지 시작 전날 부터 30일간을 기준으로,
+              <br />
+              보여지는 금액과 상이할 수 있습니다.
+            </p>
+          </div>
         </div>
-        <div className="bg-_grey-100 w-full p-4 mt-4 text-center rounded-xl text-sm font-normal">
-          <p>
-            이번 달 나의 [
-            {challengeTypeToLabel[challenge?.type as ChallengeType]}] 소비 내역
-          </p>
-          <p className="mt-1">
-            <span className="text-xl font-bold text-primary">
-              {spentMoney?.totalConsumption}
-            </span>{' '}
-            원
-          </p>
-          <p className="mt-5">
-            다음 달 &lt;카페&gt; 소비가{' '}
-            <span className="text-medium text-primary">
-              {spentMoney?.totalConsumption}
-            </span>
-            원 미만이면 성공이에요!
-          </p>
-          <p className="mt-2 text-xs leading-5 text-_grey-400">
-            소비내역 기준은 챌린지 시작 전날 부터 30일간을 기준으로,
-            <br />
-            보여지는 금액과 상이할 수 있습니다.
-          </p>
-        </div>
-      </div>
+      )}
       <div>
         <div className="flex space-x-1 items-center">
           <MoneyBag />
@@ -212,43 +272,47 @@ export default function ChallengeInfo() {
           </div>
         </div>
       </div>
-      <div>
-        <div className="flex space-x-1 items-center">
-          <Trophy />
-          <span className="text-lg font-medium">랭킹 산정 방식</span>
-        </div>
-        <p className="text-base font-medium mt-3 mb-5 text-primary">
-          랭킹 상위 10%는 상금을 더 많이 분배받아요!
-        </p>
-        <div className="bg-_grey-100 w-full p-6 mt-4 text-center rounded-xl flex flex-col gap-4">
-          <div className="flex justify-between">
-            <div className="font-normal">일일 기본 점수</div>
-            <div className="font-medium text-primary">+ 10</div>
+      {!!scoreMessages?.length && (
+        <div>
+          <div className="flex space-x-1 items-center">
+            <Trophy />
+            <span className="text-lg font-medium">랭킹 산정 방식</span>
           </div>
-          <div className="flex justify-between items-end">
-            <div className="font-normal">
-              모닝커피 참기{' '}
-              <span className="text-_grey-400 font-normal text-xs">
-                (오전 7시~ 오전 10시)
-              </span>
+          <p className="text-base font-medium mt-3 mb-5 text-primary">
+            랭킹 상위 10%는 상금을 더 많이 분배받아요!
+          </p>
+          <div className="bg-_grey-100 w-full p-6 mt-4 text-center rounded-xl flex flex-col gap-4">
+            <div className="flex justify-between">
+              <div className="font-normal">일일 기본 점수</div>
+              <div className="font-medium text-primary">+ 10</div>
             </div>
-            <div className="font-medium text-primary">+ 2</div>
-          </div>
-          <div className="flex justify-between items-end">
-            <div className="font-normal">
-              식후커피 참기{' '}
-              <span className="text-_grey-400 font-normal text-xs">
-                (오전 11시~ 오후 2시)
-              </span>
-            </div>
-            <div className="font-medium text-primary">+ 3</div>
-          </div>
-          <div className="flex justify-between">
-            <div className="font-normal">커피 마실 경우</div>
-            <div className="font-medium text-[#E91717]">- 5</div>
+            {scoreMessages?.map((message, index) => {
+              const parts = message.split(', ')
+              const description = parts[0]
+              const time = parts.length === 3 ? parts[1] : ''
+              const score = parts[parts.length - 1]
+              const scoreClass = score.startsWith('-')
+                ? 'text-_red'
+                : 'text-primary'
+
+              return (
+                <div key={message} className="flex justify-between items-end">
+                  <div className="font-normal">
+                    {description}
+                    {` `}
+                    {time && (
+                      <span className="text-_grey-400 font-normal text-xs">
+                        {time}
+                      </span>
+                    )}
+                  </div>
+                  <div className={`font-medium ${scoreClass}`}>{score}</div>
+                </div>
+              )
+            })}
           </div>
         </div>
-      </div>
+      )}
       <div className="fixed bottom-0 left-0 px-5 w-full pb-9">
         <Button text="참여하기" className="text-white" />
       </div>

--- a/src/hooks/useMenuState.ts
+++ b/src/hooks/useMenuState.ts
@@ -3,7 +3,7 @@ import { URL_WITHOUT_MENU } from '@/constants/url-map'
 import { usePathname } from 'next/navigation'
 
 function shouldShowMenu(pathname: string): boolean {
-  if (pathname === '/challenge/list') {
+  if (pathname === '/challenge/list' || pathname === '/challenge/my') {
     return true
   }
 

--- a/src/hooks/useNavState.ts
+++ b/src/hooks/useNavState.ts
@@ -11,6 +11,7 @@ const useNavState = () => {
     pathSegments.length === 0
 
   if (isPathWithoutNav) return false
+  if (pathname === '/challenge/my') return false
 
   return true
 }

--- a/src/services/challenges.ts
+++ b/src/services/challenges.ts
@@ -24,3 +24,10 @@ export const getChallengeResult = async (
   const response = await instance.get(`/challenges/result/${challengeId}`)
   return response.data
 }
+
+export const getMyChallengeList = async (memberId: string) => {
+  const response = await instance.get(`/challenges/member`, {
+    params: { memberId },
+  })
+  return response.data
+}

--- a/src/types/MyChallenge.ts
+++ b/src/types/MyChallenge.ts
@@ -1,0 +1,24 @@
+export type MemberChallengeDetail = {
+  challengeId: string
+  type: string
+  status: string
+  accountNo: string
+  startDate: string
+  endDate: string
+  title: string
+  description: string
+  image: string
+  totalDeposit: number
+  participants: number
+  memberStatus: string
+  isSuccess: boolean
+  memberDeposit: number
+  baseReward: number
+  additionalReward: number
+  totalScore: number
+}
+
+export type MyChallengeList = {
+  totalCalculatedNum: number
+  memberChallengeDetails: MemberChallengeDetail[]
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

> 메뉴바의 내 챌린지 탭을 눌렀을때 보이는 내 챌린지 페이지에 API를 연결하였습니다.
1. 상태탭에 텍스트를 변경했습니다. 또한 미정산 챌린지가 있으면 총 개수를 표시했습니다.
2. 포기하기, 정산하기 버튼을 제외한 버튼 요소에 라우팅을 진행했습니다. 
3. 진행중인 챌린지 상세 페이지의 UX 라이팅을 수정하였습니다. 

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/802143fd-ecd2-44ef-8317-a118023228be)
![image](https://github.com/user-attachments/assets/32bc873d-a644-4f1e-9636-5ed1e0a844cd)

