### PR TITLE
feat: 챌린지 더보기 상세페이지 미정산, 완료 페이지 기능 연결 작업

### DIFF
--- a/src/app/challenge/my/[challengeId]/page.tsx
+++ b/src/app/challenge/my/[challengeId]/page.tsx
@@ -3,6 +3,7 @@
 import ChallengeButton from '@/components/ChallengeButton'
 import CompletedDetail from '@/components/CompletedDetail'
 import MiniChallengeCard from '@/components/MiniChallengeCard'
+import NotRewardedDetail from '@/components/NotRewardedDetail'
 import ProgressDetail from '@/components/ProgressDetail'
 import ScheduledDetail from '@/components/ScheduledDetail'
 import { getUserInfo } from '@/services/auth'
@@ -67,7 +68,12 @@ export default function MyChallengeDetail() {
         imageUrl={challenge?.image as string}
         memberStatus={challenge?.memberStatus}
       />
-      <ChallengeButton status={status} detailPage />
+      <ChallengeButton
+        status={status}
+        type={challenge?.type as string}
+        detailPage
+        challengeId={challenge?.challengeId}
+      />
       <hr className="mt-5 mb-10" />
       {status === '참여예정' && (
         <ScheduledDetail challenge={challenge as MemberChallengeDetail} />
@@ -75,7 +81,9 @@ export default function MyChallengeDetail() {
       {status === '참여중' && (
         <ProgressDetail challenge={challenge as MemberChallengeDetail} />
       )}
-      {status === '정산필요' && <ScheduledDetail />}
+      {status === '정산필요' && (
+        <NotRewardedDetail challenge={challenge as MemberChallengeDetail} />
+      )}
       {status === '완료' && (
         <CompletedDetail challenge={challenge as MemberChallengeDetail} />
       )}

--- a/src/components/MiniChallengeCard.tsx
+++ b/src/components/MiniChallengeCard.tsx
@@ -26,12 +26,13 @@ export default function MiniChallengeCard({
   const today = new Date()
   const start = new Date(formatDate(startDate as string))
   const end = new Date(formatDate(endDate as string))
+  end.setDate(end.getDate() + 1)
 
   const challengeStatus = (() => {
     switch (true) {
       case today < start:
         return '참여 예정'
-      case today >= start && today <= end:
+      case today >= start && today < end:
         return '진행중'
       case memberStatus === 'REWARDED':
         return '완료'

--- a/src/components/MyChallengeCard.tsx
+++ b/src/components/MyChallengeCard.tsx
@@ -32,6 +32,7 @@ export default function MyChallengeCard({
   const today = new Date()
   const start = new Date(formatDate(startDate))
   const end = new Date(formatDate(endDate))
+  end.setDate(end.getDate() + 1)
 
   const challengeStatus: '참여 예정' | '진행중' | '완료' | '정산필요' = (() => {
     if (today < start) {

--- a/src/components/NotRewardedDetail.tsx
+++ b/src/components/NotRewardedDetail.tsx
@@ -14,7 +14,7 @@ import { getSpentMoneyList } from '@/services/consume'
 import { MemberChallengeDetail } from '@/types/MyChallenge'
 import { useQuery } from '@tanstack/react-query'
 
-export default function CompletedDetail({
+export default function NotRewardedDetail({
   challenge,
 }: {
   challenge: MemberChallengeDetail


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97

## 📝작업 내용

> 챌린지 더보기 상세페이지 미정산, 완료페이지의 API를 연결했습니다. 
이제 정산받기 기능과 산출물 UI 표시만 하면 내챌린지도 끝납니당, ,
